### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@ Notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- privacypass: redemption_header()
 ### Changed
+- README example to use redemption_header instead of redemption_token
 ### Deprecated
 ### Removed
 ### Fixed
+- Docstring for redemption_token
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,20 @@ Notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- privacypass: redemption_header()
 ### Changed
-- README example to use redemption_header instead of redemption_token
 ### Deprecated
 ### Removed
 ### Fixed
-- Docstring for redemption_token
 ### Security
 
-
+## [0.2.0]
+### Added
+- privacypass: redemption_header()
+### Changed
+- README example to use redemption_header instead of redemption_token
+### Fixed
+- Docstring for redemption_token
+- Cleaned up double module import
 ## [0.1.0]
 Bare minimum of [Privacy Pass protocol](https://privacypass.github.io/) to redeem tokens.
 ### Added
@@ -23,5 +27,6 @@ Bare minimum of [Privacy Pass protocol](https://privacypass.github.io/) to redee
 - docs: Firefox Token extraction steps in README
 - docs: Usage example
 
-[Unreleased]: https://github.com/sergebakharev/privacypass/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/sergebakharev/privacypass/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/sergebakharev/privacypass/releases/tag/v0.2.0
 [0.1.0]: https://github.com/sergebakharev/privacypass/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Python module implementing the Privacy Pass protocol. Privacy Pass is supporte
 
 ## Installation
 
-Simply run `pip install privacypass`. The PyPI package is at https://pypi.python.org/pypi/privacypass/
+Simply run `pip install privacypass`. The PyPI package is at [pypi.python.org/pypi/privacypass](https://pypi.python.org/pypi/privacypass)
 
 Alternatively, clone this repository and run python setup.py install.
 
@@ -26,7 +26,7 @@ Call `privacypass.redemption_token()` to create a redemption token specific to t
 import requests
 import privacypass
 
-# See `Collecting Privacy Pass Tokens` section of doc for how to retrieve tokens
+# See `Receiving Privacy Pass Tokens` section of doc for how to retrieve tokens
 cf_token = {"input":[98,207,READACTED,234,181],"factor":"0x5c57a03...REDACTED..68ef47","blindedPoint":"BAV...REDACTED...dss=","unblindedPoint":"BOu0AArK..REDACTED..jdBbeqo=","signed":{"blindedPoint":"BPs6ed..REDACTED..0ZWw=","unblindedPoint":"BHtp..REDACTED..hU0="}}
 
 url = 'https://somewhere.with.captcha'
@@ -35,16 +35,16 @@ request = requests.get(url)
 # A Privacy Pass compatible CF site is encountered
 # and a CAPTCHA challenge is presented
 if request.status_code == 403 and 'CF-Chl-Bypass' in request.headers:
-    cf_redemption_token = privacypass.redemption_token(token=cf_token, url=url, method='GET')
-    headers = {'challenge-bypass-token': cf_token}
-    request = requests_session.get(url, headers=headers)
+    cf_redemption_header = privacypass.redemption_header(token=cf_token, url=url, method='GET')
+    request = requests_session.get(url, headers=cf_redemption_header)
 ```
 
 ## Troubleshooting Notes
+
 * Tokens have a limited life span. 30 days?
 * Note the header in token redemption response `'CF-Chl-Bypass-Resp': '<error-resp>'`. \<error-resp\> is the error value returned by the privacy pass verifier. Possible values are 5 or 6, where 5 is an edge-side connection error and 6 is a pass verification error.
 
-## Recieving Privacy Pass Tokens
+## Receiving Privacy Pass Tokens
 
 Currently the easiest way to receive tokens is by having the [Browser Extension](https://privacypass.github.io/) installed, and browsing to [captcha.website](https://captcha.website).
 
@@ -53,8 +53,8 @@ Currently the easiest way to receive tokens is by having the [Browser Extension]
 
     **Firefox**
 
-    1. Browse to the [Extention Debug screen](about:debugging#/runtime/this-firefox)
-    2. *Inspect* the *Privacy Pass* extention
+    1. Browse to the *Extension Debug screen* - (about:debugging#/runtime/this-firefox)
+    2. *Inspect* the *Privacy Pass* extension
     3. Open Storage -> Local Storage
     4. Tokens are stored as a list under the `cf-tokens` key.
 

--- a/privacypass/__init__.py
+++ b/privacypass/__init__.py
@@ -1,0 +1,1 @@
+from .privacypass import redemption_header, redemption_token  # noqa

--- a/privacypass/privacypass.py
+++ b/privacypass/privacypass.py
@@ -18,7 +18,7 @@ def _get_mac_key(token):
 
 
 def redemption_token(token, url: str, method: str) -> str:
-    """Creates a request base64 string of HMAC("hash_request_binding", <derived-key>, <shared-info>)
+    """Creates a Privacy Pass redemption token
 
 Args:
     token: A single Privacy Pass CF-Token dict
@@ -48,3 +48,18 @@ Return:
     json_string = json.dumps(redemption_dict, separators=(',', ':'))
     redemption_token = b64encode(json_string.encode('utf-8'))
     return redemption_token.decode('utf-8')  # return str not bytes
+
+
+def redemption_header(token, url: str, method: str) -> dict:
+    """Returns a request header with appropriate redemption token
+
+Args:
+    token: A single Privacy Pass CF-Token dict
+    url: URL being requested
+    method: HTTP verb that will be used with the token. Eg. GET or POST
+
+Return:
+    dict: Header with challenge-bypass-token token
+    """
+    redemption_token(token=token, url=url, method=method)
+    return {'challenge-bypass-token': redemption_token}


### PR DESCRIPTION
## [0.2.0]
### Added
- privacypass: redemption_header()
### Changed
- README example to use redemption_header instead of redemption_token
### Fixed
- Docstring for redemption_token
- Cleaned up double module import